### PR TITLE
feat: handle hardware back press and onClose event bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aerosync-react-native-sdk",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "This React Native SDK provides an interface to load Aerosync-UI in React Native application. Securely link your bank account through your bank’s website. Log in with a fast, secure, and tokenized connection. Your information is never shared or sold.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/BankLink.tsx
+++ b/src/BankLink.tsx
@@ -1,4 +1,5 @@
-import { View, StyleSheet, Linking, BackHandler } from 'react-native';
+import React from 'react';
+import { View, StyleSheet, Linking, BackHandler, Platform } from 'react-native';
 import { useState, useEffect } from 'react';
 import { type Options } from './Types';
 import { WebView, type WebViewNavigation } from 'react-native-webview';
@@ -28,7 +29,6 @@ export default function BankLink(options: Options) {
 
   const [source, setSource] = useState(base_url);
   let canGoBack = false;
-  let widgetClosed = false;
   let webViewRef: any;
 
   useEffect(() => {
@@ -37,33 +37,23 @@ export default function BankLink(options: Options) {
        * When true is returned the event will not be bubbled up
        * & no other back action will execute
        */
-      if (canGoBack && webViewRef) {
-        webViewRef.goBack();
-        return true;
-      } else {
-        return false;
-      }
+      if (canGoBack && webViewRef) webViewRef.goBack();
+      else options.onClose();
+      return true;
     };
-    // the backhandler API detects hardware button presses for back navigatio
-    BackHandler.addEventListener('hardwareBackPress', onBackPress);
+    // the backhandler API detects hardware button presses for back navigation
+    if (Platform.OS === 'android')
+      BackHandler.addEventListener('hardwareBackPress', onBackPress);
     return () => {
-      if (!widgetClosed) {
-        options.onClose();
-      }
-      BackHandler.removeEventListener('hardwareBackPress', onBackPress);
+      if (Platform.OS === 'android')
+        BackHandler.removeEventListener('hardwareBackPress', onBackPress);
     };
-  }, [options, widgetClosed, canGoBack, webViewRef]);
+  });
 
   const handleNavigationStateChange = (NavState: WebViewNavigation) => {
     const { url } = NavState;
     canGoBack = NavState.canGoBack;
-    if (
-      url.includes('aerosync.com/redirect') &&
-      !url.includes('&token=') &&
-      !options.deeplink
-    ) {
-      setSource(`${url}&token=${options.token}`);
-    }
+    if (url.includes('/bank/connect')) canGoBack = false;
   };
 
   return (
@@ -76,11 +66,9 @@ export default function BankLink(options: Options) {
           const r = JSON.parse(event.nativeEvent.data);
           switch (r.type) {
             case 'pageSuccess':
-              widgetClosed = true;
               options.onSuccess && options.onSuccess(r.payload);
               break;
             case 'widgetClose':
-              widgetClosed = true;
               options.onClose && options.onClose();
               break;
             case 'widgetPageLoaded':
@@ -96,7 +84,9 @@ export default function BankLink(options: Options) {
         ref={(webView) => (webViewRef = webView)}
         onLoad={() => options.onLoad()}
         onNavigationStateChange={handleNavigationStateChange}
-        limitsNavigationsToAppBoundDomains= {options?.limitsNavigationsToAppBoundDomains || false}
+        limitsNavigationsToAppBoundDomains={
+          options?.limitsNavigationsToAppBoundDomains || false
+        }
         onOpenWindow={(syntheticEvent) => {
           const { nativeEvent } = syntheticEvent;
           const { targetUrl } = nativeEvent;

--- a/src/BankLink.tsx
+++ b/src/BankLink.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, StyleSheet, Linking, BackHandler, Platform } from 'react-native';
 import { useState, useEffect } from 'react';
 import { type Options } from './Types';

--- a/src/BankLink.tsx
+++ b/src/BankLink.tsx
@@ -102,8 +102,8 @@ export default function BankLink(options: Options) {
 
 // environment constants
 const env: { [key: string]: string } = {
-  dev: 'https://dev.aerosync.com',
-  staging: 'https://staging.aerosync.com',
+  dev: 'https://qa-sync.aero.inc',
+  staging: 'https://staging-sync.aero.inc',
   sandbox: 'https://sandbox.aerosync.com',
-  production: 'https://www.aerosync.com',
+  production: 'https://sync.aero.inc',
 };


### PR DESCRIPTION
# What changed?
- Handle hardware back press and onClose event bug
- Updated the environment domain to aero.inc

# What to test?

## Android 
- Basic sanity testing of MFA & OAuth [MX | Fiserv | Akoya]
- Test the system back button using 3-button navigation. To turn ON 3-button navigation see here. https://support.google.com/android/answer/9079644?hl=en
![image](https://github.com/user-attachments/assets/c50093ef-2957-4343-8ce6-6ea90ddb24e6)
- Click system back button at any point and confirm whether user can see the previous screen (for eg: If user is on bank list page and clicks the system back button then they should see landing page).
- If user is on landing page and user clicks on system back button, then the widget should be closed.